### PR TITLE
Paginated Event Fetching

### DIFF
--- a/advisor-backend/routes/events.js
+++ b/advisor-backend/routes/events.js
@@ -3,6 +3,16 @@ import { EventDetails } from "../models/event.js";
 const pageLimit = 8;
 const router = express.Router();
 
+router.get("/page-count", async (req, res) => {
+  try {
+    const count = await EventDetails.count();
+    const pageCount = Math.ceil(count / pageLimit);
+    res.status(200).json({ pageCount });
+  } catch (error) {
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
 router.get("/:page", async (req, res) => {
   const page = req.params.page;
   try {

--- a/advisor-backend/routes/events.js
+++ b/advisor-backend/routes/events.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { EventDetails } from "../models/event.js";
+// number of elements to be displayed on the page
 const pageLimit = 8;
 const router = express.Router();
 

--- a/advisor-backend/routes/events.js
+++ b/advisor-backend/routes/events.js
@@ -1,11 +1,15 @@
 import express from "express";
 import { EventDetails } from "../models/event.js";
-
+const pageLimit = 8;
 const router = express.Router();
 
-router.get("/", async (req, res) => {
+router.get("/:page", async (req, res) => {
+  const page = req.params.page;
   try {
-    const events = await EventDetails.findAll();
+    const events = await EventDetails.findAll({
+      limit: pageLimit,
+      offset: (page - 1) * pageLimit,
+    });
     res.json({ events });
   } catch (error) {
     res.status(500).json({ error: "Server error" });

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.css
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.css
@@ -27,3 +27,10 @@
 #volunteer-history:hover {
   color: lightgray;
 }
+
+.pagination {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
@@ -4,6 +4,7 @@ import Explore from "../../components/Explore/Explore";
 import { Link } from "react-router-dom";
 import axios from "axios";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import Pagination from "@mui/material/Pagination";
 
 export default function VolunteerExplore() {
   const [events, setEvents] = useState([]);
@@ -50,6 +51,14 @@ export default function VolunteerExplore() {
           </Link>
         </div>
         <Explore events={events} />
+        {pageCount !== null && (
+          <div className="pagination">
+            <Pagination
+              count={pageCount}
+              onChange={(event, page) => fetchEvents(page)}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
@@ -8,9 +8,11 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 export default function VolunteerExplore() {
   const [events, setEvents] = useState([]);
 
-  const fetchEvents = async () => {
+  const fetchEvents = async (page) => {
     try {
-      const res = await axios.get("http://localhost:5000/api/events/");
+      const res = await axios.get(`http://localhost:5000/api/events/${page}`, {
+        params: { page },
+      });
       const fetchedEvents = res.data.events;
       setEvents(fetchedEvents);
     } catch (error) {
@@ -19,7 +21,7 @@ export default function VolunteerExplore() {
   };
 
   useEffect(() => {
-    fetchEvents();
+    fetchEvents(1);
   }, []);
 
   return (

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
@@ -10,7 +10,7 @@ export default function VolunteerExplore() {
   const [events, setEvents] = useState([]);
   const [pageCount, setPageCount] = useState(null);
 
-  const fetchEvents = async (page) => {
+  const fetchEventsByPage = async (page) => {
     try {
       const res = await axios.get(`http://localhost:5000/api/events/${page}`, {
         params: { page },
@@ -36,7 +36,7 @@ export default function VolunteerExplore() {
 
   useEffect(() => {
     fetchPageCount();
-    fetchEvents(1);
+    fetchEventsByPage(1);
   }, []);
 
   return (
@@ -55,7 +55,7 @@ export default function VolunteerExplore() {
           <div className="pagination">
             <Pagination
               count={pageCount}
-              onChange={(event, page) => fetchEvents(page)}
+              onChange={(event, page) => fetchEventsByPage(page)}
             />
           </div>
         )}

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
@@ -7,6 +7,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 
 export default function VolunteerExplore() {
   const [events, setEvents] = useState([]);
+  const [pageCount, setPageCount] = useState(null);
 
   const fetchEvents = async (page) => {
     try {
@@ -20,7 +21,20 @@ export default function VolunteerExplore() {
     }
   };
 
+  const fetchPageCount = async () => {
+    try {
+      const res = await axios.get(
+        "http://localhost:5000/api/events/page-count"
+      );
+      const pageCount = res.data.pageCount;
+      setPageCount(pageCount);
+    } catch (error) {
+      alert("Something went wrong. Try again later.");
+    }
+  };
+
   useEffect(() => {
+    fetchPageCount();
     fetchEvents(1);
   }, []);
 


### PR DESCRIPTION
Updating event fetching to be paginated for the purpose of minimizing network data transfer for application.

1. Server-side global variable for pageLimit to adjust how many elements are displayed on the page at a time (will be adjusted later, set to specific limit to display pagination)
2. Updated existing server-side route for fetching events using sequelize offset and limit for paginated queries
3. Added a page-count route to Express server to calculate the number of pages needed to display data, use in MUI Pagination component
4. On the front end, updated existing fetch function for paginated queries
5. On the front end, implemented a function to fetch page count from Server, sent to Pagination component as prop

Overview: Page 1
![image](https://github.com/DayRB25/MetaUFinal/assets/80652550/be2bd866-0499-4e27-91b3-62d6ef7c3655)

Overview: Page 2
![image](https://github.com/DayRB25/MetaUFinal/assets/80652550/7fa36f69-12a8-45be-95cd-726a0435dcd2)
