### PR TITLE
Course schedule fixes

### DIFF
--- a/advisor-backend/routes/schedule.js
+++ b/advisor-backend/routes/schedule.js
@@ -412,7 +412,8 @@ router.post("/create", async (req, res) => {
     const numberOfElectivesTaken = takenClassesData.filter(
       (takenClass) => !requiredClassesSet.has(takenClass)
     ); // everything in taken that is not required
-    let numberOfRemainingElectives = numberOfElectives - numberOfElectivesTaken;
+    let numberOfRemainingElectives =
+      numberOfElectives - numberOfElectivesTaken.length;
 
     // need overall adjacency matrix again, remove all taken courses (including those in adjList), should be left with only the non-required courses
     for (const element in electiveAdditionAdjList) {
@@ -490,7 +491,7 @@ router.post("/create", async (req, res) => {
       sortedPreReqPaths = Object.entries(preReqPaths);
       sortedPreReqPaths.sort((a, b) => a[1].count - b[1].count);
     }
-    if (electivesTaken.length < 6) {
+    if (numberOfRemainingElectives > 0) {
       // schedule not valid
       return res.json({
         message: "Invalid schedule. Please enter a later goal graduation date",

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -82,7 +82,7 @@ export default function ScheduleTool() {
         "http://localhost:5000/api/schedule/create",
         body
       );
-      if (res.data.schedule === undefined) {
+      if (res.data.schedule === undefined || res.data.schedule === null) {
         alert("Schedule not possible. Enter new constraints.");
         return;
       }


### PR DESCRIPTION
Fixes for course schedule tool
1. Appropriately accounting for the number of electives a student has already taken
2. Adjusting invalid schedule condition for the case a student has already taken some electives-- schedule is invalid if (after adding all electives that could fit within the schedule) the student has not satisfied the number of electives to be taken
3. On the frontend, handle additional invalid schedule condition when schedule is null