### PR TITLE
Backend logic implementation for allowing users to swap classes

### DIFF
--- a/advisor-backend/routes/schedule.js
+++ b/advisor-backend/routes/schedule.js
@@ -1006,4 +1006,22 @@ router.post("/full-year-options", (req, res) => {
   }
 });
 
+router.post("/swap", (req, res) => {
+  const courses = req.body.courses;
+  const schedule = req.body.schedule;
+
+  const scheduleObject = {};
+  createScheduleObject(schedule, scheduleObject);
+
+  const courseOne = courses[0];
+  const courseTwo = courses[1];
+
+  const courseYearOne = findCourseYear(scheduleObject, courseOne);
+  const courseYearTwo = findCourseYear(scheduleObject, courseTwo);
+
+  moveCourseToDifferentYear(schedule, courseYearTwo, courseYearOne, courseOne);
+  moveCourseToDifferentYear(schedule, courseYearOne, courseYearTwo, courseTwo);
+  return res.status(200).json({ schedule });
+});
+
 export default router;

--- a/advisor-backend/routes/schedule.js
+++ b/advisor-backend/routes/schedule.js
@@ -39,6 +39,58 @@ const calculateInDegrees = (
   }
 };
 
+const checkDesiredYearAndBefore = (
+  scheduleObject,
+  desiredYear,
+  postReqsSet
+) => {
+  let validMoveFlag = true;
+  for (const year in scheduleObject) {
+    // only check desiredYear and before
+    if (parseInt(year) <= desiredYear) {
+      const coursesSet = scheduleObject[year];
+      postReqsSet.forEach((postReq) => {
+        if (coursesSet.has(postReq)) {
+          // invalid schedule
+          validMoveFlag = false;
+        }
+      });
+    }
+  }
+  return validMoveFlag;
+};
+
+const checkDesiredYearAndAfter = (scheduleObject, desiredYear, preReqsSet) => {
+  let validMoveFlag = true;
+  for (const year in scheduleObject) {
+    // only check desiredYear and after
+    if (parseInt(year) >= desiredYear) {
+      const coursesSet = scheduleObject[year];
+      preReqsSet.forEach((preReq) => {
+        if (coursesSet.has(preReq)) {
+          // invalid schedule
+          validMoveFlag = false;
+        }
+      });
+    }
+  }
+  return validMoveFlag;
+};
+
+const createScheduleObject = (schedule, scheduleObject) => {
+  for (let i = 0; i < schedule.length; i++) {
+    const year = schedule[i];
+    const yearSemester = year.semesters[0];
+    const yearClasses = yearSemester.classes;
+    const yearSet = new Set();
+    for (let j = 0; j < yearClasses.length; j++) {
+      const course = yearClasses[j];
+      yearSet.add(course.id);
+    }
+    scheduleObject[year.number] = yearSet;
+  }
+};
+
 const countNodes = (sourceNode, graph) => {
   const visited = new Set();
   dfsToCount(sourceNode, graph, visited);
@@ -112,10 +164,28 @@ const dfsToCount = (node, graph, visited) => {
 const findAllPrerequisites = (course, graph, prereqs) => {
   for (const prereq of graph[course]) {
     if (!prereqs.has(prereq)) {
-      prereqs.add(prereq);
+      prereqs.add(parseInt(prereq));
       findAllPrerequisites(prereq, graph, prereqs);
     }
   }
+};
+
+const findAllPostrequisites = (node, adjList, postReqSet) => {
+  for (const postreq of adjList[node]) {
+    if (!postReqSet.has(postreq)) {
+      postReqSet.add(postreq);
+      findAllPostrequisites(postreq, adjList, postReqSet);
+    }
+  }
+};
+
+const findCourseYear = (scheduleObject, course) => {
+  for (const year in scheduleObject) {
+    if (scheduleObject[year].has(course.id)) {
+      return parseInt(year);
+    }
+  }
+  return -1;
 };
 
 const generateTopologicalSort = (
@@ -206,6 +276,47 @@ const generateSchedule = async (
     years[potentialYear].semesters[1].classes.push(courseInfo);
   }
   return years;
+};
+
+const moveCourseToDifferentYear = (
+  schedule,
+  desiredYear,
+  originalYear,
+  course
+) => {
+  for (let i = 0; i < schedule.length; i++) {
+    const year = schedule[i];
+    // delete it from this year
+    if (year.number === originalYear) {
+      // for both semesters
+      year.semesters[0].classes = year.semesters[0].classes.filter(
+        (classItem) => classItem.id !== course.id
+      );
+      year.semesters[1].classes = year.semesters[0].classes.filter(
+        (classItem) => classItem.id !== course.id
+      );
+    }
+
+    // add it to this year
+    if (year.number === desiredYear) {
+      year.semesters[0].classes.push(course);
+      year.semesters[1].classes.push(course);
+    }
+  }
+};
+
+const reverseAdjList = (adjList) => {
+  let reversedAdjList = {};
+  for (const node in adjList) {
+    reversedAdjList[node] = [];
+  }
+
+  for (const node in adjList) {
+    for (const neighbor of adjList[node]) {
+      reversedAdjList[neighbor].push(node);
+    }
+  }
+  return reversedAdjList;
 };
 
 // Route for student schedule creation
@@ -655,6 +766,90 @@ router.post("/create", async (req, res) => {
     res.json({ schedule });
   } catch (error) {
     res.status(500).json({ error: "Server error" });
+  }
+});
+
+// this route handles course swaps into years that are not full of classes already
+router.post("/nonfull", (req, res) => {
+  // schedule array (array of year objects)
+  const schedule = req.body.schedule;
+  // original adjList for the schedule, need this to verify validity of schedule
+  const scheduleAdjList = req.body.scheduleAdjList;
+  // course I want to shift
+  const courseToChange = req.body.courseToChange;
+  // year I want to shift it to
+  const desiredYear = req.body.desiredYear;
+
+  // reverse scheduleAdjList
+  const reverseScheduleAdjList = reverseAdjList(scheduleAdjList);
+
+  // create array of year sets, each set contains the classes for that year
+  const scheduleObject = {};
+  createScheduleObject(schedule, scheduleObject);
+
+  // find year of course to be moved
+  const courseYear = findCourseYear(scheduleObject, courseToChange);
+
+  // nothing to be done
+  if (courseYear === desiredYear) {
+    return res.json({ message: "Swapping into current year" });
+  }
+
+  // if the course's year is before the desired year, the course is being moved forward
+  // for a forward move, need to check if course is coming after it's postreqs
+  if (courseYear < desiredYear) {
+    // find postReqs ////
+    const postReqsSet = new Set();
+    findAllPostrequisites(courseToChange.id, scheduleAdjList, postReqsSet);
+
+    // now to check through the relevant years in scheduleObject for any of the postReqs //
+    const validForwardMove = checkDesiredYearAndBefore(
+      scheduleObject,
+      desiredYear,
+      postReqsSet
+    );
+
+    if (validForwardMove) {
+      // valid move
+      moveCourseToDifferentYear(
+        schedule,
+        desiredYear,
+        courseYear,
+        courseToChange
+      );
+      return res.status(200).json({ message: "Success", schedule });
+    } else {
+      // invalid move
+      return res.status(200).json({ message: "Invalid" });
+    }
+  } else {
+    // if the course's year is after the desired year, the course is being moved back
+    // for a backward move, need to check if course is coming before it's prereqs
+
+    // find preReqs ////
+    const preReqsSet = new Set();
+    findAllPrerequisites(courseToChange.id, reverseScheduleAdjList, preReqsSet);
+
+    // now to check through the relevant years in scheduleObject for any of the postReqs //
+    const validBackMove = checkDesiredYearAndAfter(
+      scheduleObject,
+      desiredYear,
+      preReqsSet
+    );
+
+    if (validBackMove) {
+      // valid move
+      moveCourseToDifferentYear(
+        schedule,
+        desiredYear,
+        courseYear,
+        courseToChange
+      );
+      return res.status(200).json({ message: "Success", schedule });
+    } else {
+      // invalid move
+      return res.status(200).json({ message: "Invalid" });
+    }
   }
 });
 


### PR DESCRIPTION
Backend logic implementation for allowing users to swap classes

Endpoints:
1. /nonfull
Handles swap into a year that is not full
2. /full-swap-options
Returns an array of valid swap options amongst classes in a full year
3. /swap
Takes two classes and a schedule and completes a swap

Swap Directions:
1. Forward
For a forward swap, a course is being moved forward in the course schedule. This means it could potentially be placed in front of its post-reqs (courses that must come after). Thus, to verify validity of swap, must check the desired swap year and any year before for any of the courses postreqs. If find one, invalid swap
7. Backward
Backward swap similar, but instead the move is backwards. Thus, the course could now come before its pre-reqs. To verify validity of swap, check desired sway year and any year after to check for any pre-reqs. If any found, invalid swap

Swap Options:
1. Into non-full year (less than 6 classes)
For a non-full year, its not much of a swap-- more like a move. Simply verify the swap does not violate the conditions above for either forward or backward swap
2. Into full year (6 classes)
Full year is slightly different because the course must be swapped with another in that year. Thus, for every course in the full year, swap positions with desired course to move and verify schedule. If schedule valid, add to an array of valid swaps

This info is intended to be returned to the user, then the user chooses which course from the valid options, and the swap endpoint handles the actual swap