### PR TITLE
Course Swap Frontend

### DIFF
--- a/advisor-backend/routes/schedule.js
+++ b/advisor-backend/routes/schedule.js
@@ -777,7 +777,7 @@ router.post("/create", async (req, res) => {
       student.year
     );
 
-    res.json({ schedule });
+    res.json({ schedule, finalScheduleAdjList });
   } catch (error) {
     res.status(500).json({ error: "Server error" });
   }

--- a/advisor-ui/src/components/ClassDetails/ClassDetails.jsx
+++ b/advisor-ui/src/components/ClassDetails/ClassDetails.jsx
@@ -1,9 +1,13 @@
 import React from "react";
 import "./ClassDetails.css";
 
-export default function ClassDetails({ classItem, displayYear }) {
+export default function ClassDetails({
+  classItem,
+  displayYear,
+  handleOpenModal = () => {},
+}) {
   return (
-    <div className="class-details">
+    <div className="class-details" onClick={(event) => handleOpenModal(event)}>
       <p>{classItem.name}</p>
       {displayYear && (
         <div className="details">

--- a/advisor-ui/src/components/ClassDetails/ClassDetails.jsx
+++ b/advisor-ui/src/components/ClassDetails/ClassDetails.jsx
@@ -7,7 +7,10 @@ export default function ClassDetails({
   handleOpenModal = () => {},
 }) {
   return (
-    <div className="class-details" onClick={(event) => handleOpenModal(event)}>
+    <div
+      className="class-details"
+      onClick={(event) => handleOpenModal(event, classItem)}
+    >
       <p>{classItem.name}</p>
       {displayYear && (
         <div className="details">

--- a/advisor-ui/src/components/ScheduleDetails/ScheduleDetails.jsx
+++ b/advisor-ui/src/components/ScheduleDetails/ScheduleDetails.jsx
@@ -8,12 +8,14 @@ export default function ScheduleDetails({
   year,
   displayYear,
   handleCloseYear,
+  handleOpenModal,
 }) {
   const yearItems = years.map((year, index) => (
     <YearDetails
       key={index}
       year={year}
       handleDisplayYear={handleDisplayYear}
+      handleOpenModal={handleOpenModal}
     />
   ));
   return (

--- a/advisor-ui/src/components/SemesterDetails/SemesterDetails.jsx
+++ b/advisor-ui/src/components/SemesterDetails/SemesterDetails.jsx
@@ -2,9 +2,18 @@ import React from "react";
 import "./SemesterDetails.css";
 import ClassDetails from "../ClassDetails/ClassDetails";
 
-export default function SemesterDetails({ semester, displayYear }) {
+export default function SemesterDetails({
+  semester,
+  displayYear,
+  handleOpenModal,
+}) {
   const classItems = semester.classes.map((classItem, index) => (
-    <ClassDetails key={index} classItem={classItem} displayYear={displayYear} />
+    <ClassDetails
+      key={index}
+      classItem={classItem}
+      displayYear={displayYear}
+      handleOpenModal={handleOpenModal}
+    />
   ));
   return (
     <div className="semester-details">

--- a/advisor-ui/src/components/SwapModal/SwapModal.css
+++ b/advisor-ui/src/components/SwapModal/SwapModal.css
@@ -1,0 +1,5 @@
+.swap-modal .content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -52,7 +52,7 @@ export default function SwapModal({
       <div className="content">
         <h4>Year Swap:</h4>
         {options === null && (
-          <p>{`What year do you to move ${courseName} to?`}</p>
+          <p>{`What year do you want to move ${courseName} to?`}</p>
         )}
         {options !== null && (
           <p>{`In year ${year}, what course do you wish to swap ${courseName} with?`}</p>

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -11,6 +11,7 @@ export default function SwapModal({
   years,
   handleSubmitSwapRequest,
   options,
+  submitCourseSwapRequest,
 }) {
   const [year, setYear] = useState(-1);
   const [course, setCourse] = useState("");
@@ -21,6 +22,14 @@ export default function SwapModal({
 
   const handleChangeCourse = (event) => {
     setCourse(event.target.value);
+  };
+
+  const handleSubmit = () => {
+    if (options !== null) {
+      submitCourseSwapRequest(course, year);
+    } else {
+      handleSubmitSwapRequest(year);
+    }
   };
 
   const yearOptions = years.map((year, idx) => (
@@ -71,10 +80,7 @@ export default function SwapModal({
             </Select>
           </FormControl>
         )}
-        <Button
-          variant="outlined"
-          onClick={() => handleSubmitSwapRequest(year)}
-        >
+        <Button variant="outlined" onClick={handleSubmit}>
           Submit
         </Button>
       </div>

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 import { Button } from "@mui/material";
 import { FormControl } from "@mui/material";
 import { Select } from "@mui/material";
@@ -7,6 +7,11 @@ import { MenuItem } from "@mui/material";
 import "./SwapModal.css";
 
 export default function SwapModal({ courseName, years }) {
+  const [year, setYear] = useState(-1);
+  const handleChangeYear = (event) => {
+    setYear(parseInt(event.target.value));
+  };
+
   const yearOptions = years.map((year, idx) => (
     <MenuItem key={idx} value={year}>
       {year}
@@ -22,8 +27,9 @@ export default function SwapModal({ courseName, years }) {
           <Select
             labelId="select-label"
             id="simple-select"
-            value=""
+            value={year !== -1 ? year : ""}
             label="Year"
+            onChange={handleChangeYear}
           >
             {yearOptions}
           </Select>

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -51,7 +51,12 @@ export default function SwapModal({
     <div className="swap-modal">
       <div className="content">
         <h4>Year Swap:</h4>
-        <p>{`What year do you want to move ${courseName} to?`}</p>
+        {options === null && (
+          <p>{`What year do you to move ${courseName} to?`}</p>
+        )}
+        {options !== null && (
+          <p>{`In year ${year}, what course do you wish to swap ${courseName} with?`}</p>
+        )}
         {options === null && (
           <FormControl sx={{ minWidth: 120 }} size="small">
             <InputLabel id="select-label">Year</InputLabel>

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -6,7 +6,11 @@ import { InputLabel } from "@mui/material";
 import { MenuItem } from "@mui/material";
 import "./SwapModal.css";
 
-export default function SwapModal({ courseName, years }) {
+export default function SwapModal({
+  courseName,
+  years,
+  handleSubmitSwapRequest,
+}) {
   const [year, setYear] = useState(-1);
   const handleChangeYear = (event) => {
     setYear(parseInt(event.target.value));
@@ -34,7 +38,12 @@ export default function SwapModal({ courseName, years }) {
             {yearOptions}
           </Select>
         </FormControl>
-        <Button variant="outlined">Submit</Button>
+        <Button
+          variant="outlined"
+          onClick={() => handleSubmitSwapRequest(year)}
+        >
+          Submit
+        </Button>
       </div>
     </div>
   );

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -1,5 +1,5 @@
 import React from "react";
 
-export default function SwapModal() {
-  return <div>SwapModal</div>;
+export default function SwapModal({ courseName }) {
+  return <div>{courseName}</div>;
 }

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -13,8 +13,14 @@ export default function SwapModal({
   options,
 }) {
   const [year, setYear] = useState(-1);
+  const [course, setCourse] = useState("");
+
   const handleChangeYear = (event) => {
     setYear(parseInt(event.target.value));
+  };
+
+  const handleChangeCourse = (event) => {
+    setCourse(event.target.value);
   };
 
   const yearOptions = years.map((year, idx) => (
@@ -57,8 +63,9 @@ export default function SwapModal({
             <Select
               labelId="select-label"
               id="simple-select"
-              value=""
+              value={course}
               label="Course"
+              onChange={handleChangeCourse}
             >
               {optionsDisplay}
             </Select>

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -3,9 +3,15 @@ import { Button } from "@mui/material";
 import { FormControl } from "@mui/material";
 import { Select } from "@mui/material";
 import { InputLabel } from "@mui/material";
+import { MenuItem } from "@mui/material";
 import "./SwapModal.css";
 
-export default function SwapModal({ courseName }) {
+export default function SwapModal({ courseName, years }) {
+  const yearOptions = years.map((year, idx) => (
+    <MenuItem key={idx} value={year}>
+      {year}
+    </MenuItem>
+  ));
   return (
     <div className="swap-modal">
       <div className="content">
@@ -18,7 +24,9 @@ export default function SwapModal({ courseName }) {
             id="simple-select"
             value=""
             label="Year"
-          ></Select>
+          >
+            {yearOptions}
+          </Select>
         </FormControl>
         <Button variant="outlined">Submit</Button>
       </div>

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -1,5 +1,26 @@
 import React from "react";
+import { Button } from "@mui/material";
+import { FormControl } from "@mui/material";
+import { Select } from "@mui/material";
+import { InputLabel } from "@mui/material";
 
 export default function SwapModal({ courseName }) {
-  return <div>{courseName}</div>;
+  return (
+    <div className="swap-modal">
+      <div className="content">
+        <h4>Year Swap:</h4>
+        <p>{`What year do you want to move ${courseName} to?`}</p>
+        <FormControl sx={{ minWidth: 120 }} size="small">
+          <InputLabel id="select-label">Year</InputLabel>
+          <Select
+            labelId="select-label"
+            id="simple-select"
+            value=""
+            label="Year"
+          ></Select>
+        </FormControl>
+        <Button variant="outlined">Submit</Button>
+      </div>
+    </div>
+  );
 }

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -10,6 +10,7 @@ export default function SwapModal({
   courseName,
   years,
   handleSubmitSwapRequest,
+  options,
 }) {
   const [year, setYear] = useState(-1);
   const handleChangeYear = (event) => {
@@ -21,23 +22,48 @@ export default function SwapModal({
       {year}
     </MenuItem>
   ));
+
+  let optionsDisplay = [];
+  if (options !== null) {
+    optionsDisplay = options.map((courseOption, idx) => (
+      <MenuItem key={idx} value={courseOption}>
+        {courseOption}
+      </MenuItem>
+    ));
+  }
+
   return (
     <div className="swap-modal">
       <div className="content">
         <h4>Year Swap:</h4>
         <p>{`What year do you want to move ${courseName} to?`}</p>
-        <FormControl sx={{ minWidth: 120 }} size="small">
-          <InputLabel id="select-label">Year</InputLabel>
-          <Select
-            labelId="select-label"
-            id="simple-select"
-            value={year !== -1 ? year : ""}
-            label="Year"
-            onChange={handleChangeYear}
-          >
-            {yearOptions}
-          </Select>
-        </FormControl>
+        {options === null && (
+          <FormControl sx={{ minWidth: 120 }} size="small">
+            <InputLabel id="select-label">Year</InputLabel>
+            <Select
+              labelId="select-label"
+              id="simple-select"
+              value={year !== -1 ? year : ""}
+              label="Year"
+              onChange={handleChangeYear}
+            >
+              {yearOptions}
+            </Select>
+          </FormControl>
+        )}
+        {options !== null && (
+          <FormControl sx={{ minWidth: 120 }} size="small">
+            <InputLabel id="select-label">Course</InputLabel>
+            <Select
+              labelId="select-label"
+              id="simple-select"
+              value=""
+              label="Course"
+            >
+              {optionsDisplay}
+            </Select>
+          </FormControl>
+        )}
         <Button
           variant="outlined"
           onClick={() => handleSubmitSwapRequest(year)}

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function SwapModal() {
+  return <div>SwapModal</div>;
+}

--- a/advisor-ui/src/components/SwapModal/SwapModal.jsx
+++ b/advisor-ui/src/components/SwapModal/SwapModal.jsx
@@ -3,6 +3,7 @@ import { Button } from "@mui/material";
 import { FormControl } from "@mui/material";
 import { Select } from "@mui/material";
 import { InputLabel } from "@mui/material";
+import "./SwapModal.css";
 
 export default function SwapModal({ courseName }) {
   return (

--- a/advisor-ui/src/components/YearDetails/YearDetails.jsx
+++ b/advisor-ui/src/components/YearDetails/YearDetails.jsx
@@ -6,12 +6,14 @@ export default function YearDetails({
   year,
   handleDisplayYear = () => {},
   displayYear = false,
+  handleOpenModal,
 }) {
   const semesterItems = year.semesters.map((semester, index) => (
     <SemesterDetails
       key={index}
       semester={semester}
       displayYear={displayYear}
+      handleOpenModal={handleOpenModal}
     />
   ));
   return (

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -8,6 +8,8 @@ import { UserContext } from "../../UserContext.js";
 import "./ScheduleTool.css";
 import Constraints from "../../components/Constraints/Constraints";
 import ScheduleDetails from "../../components/ScheduleDetails/ScheduleDetails";
+import Modal from "../../components/Modal/Modal";
+import SwapModal from "../../components/SwapModal/SwapModal.jsx";
 
 export default function ScheduleTool() {
   const [constraints, setConstraints] = useState([]);
@@ -15,6 +17,16 @@ export default function ScheduleTool() {
   const [displayYear, setDisplayYear] = useState(false);
   const [year, setYear] = useState(null);
   const { user } = useContext(UserContext);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpenModal = (e) => {
+    e.stopPropagation();
+    setIsOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsOpen(false);
+  };
 
   const handleDisplayYear = (number) => {
     const yearIdx = schedule.findIndex((year) => year.number === number);
@@ -110,6 +122,12 @@ export default function ScheduleTool() {
           year={year}
           displayYear={displayYear}
           handleCloseYear={handleCloseYear}
+          handleOpenModal={handleOpenModal}
+        />
+        <Modal
+          isOpen={isOpen}
+          handleCloseModal={handleCloseModal}
+          content={<SwapModal />}
         />
       </div>
     </div>

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -186,6 +186,40 @@ export default function ScheduleTool() {
     }
   };
 
+  const getYearIdxFromYearNumber = (yearNumber) => {
+    return schedule.findIndex((year) => year.number === yearNumber);
+  };
+
+  const getCourseFromName = (courseName, desiredYear) => {
+    const yearIdx = getYearIdxFromYearNumber(desiredYear);
+    const courseIdx = schedule[yearIdx].semesters[0].classes.findIndex(
+      (course) => course.name === courseName
+    );
+    return schedule[yearIdx].semesters[0].classes[courseIdx];
+  };
+
+  const submitCourseSwapRequest = async (course, desiredYear) => {
+    const courses = [];
+    const courseToSwap = getCourseFromName(course, desiredYear);
+    courses.push(courseToChange);
+    courses.push(courseToSwap);
+    const body = {
+      schedule,
+      courses,
+    };
+    try {
+      const res = await axios.post(
+        "http://localhost:5000/api/schedule/swap",
+        body
+      );
+      setSchedule(res.data.schedule);
+      handleCloseModal();
+      setOptions(null);
+    } catch (error) {
+      alert("Something went wrong.");
+    }
+  };
+
   return (
     <div className="schedule-tool">
       <div className="content">
@@ -215,6 +249,7 @@ export default function ScheduleTool() {
               years={extractYearsWithoutCourseYear(courseToChange)}
               handleSubmitSwapRequest={handleSubmitSwapRequest}
               options={options}
+              submitCourseSwapRequest={submitCourseSwapRequest}
             />
           }
         />

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -106,6 +106,26 @@ export default function ScheduleTool() {
     }
   };
 
+  const getYearNumberFromCourse = (course) => {
+    for (let i = 0; i < schedule.length; i++) {
+      const year = schedule[i];
+      const classes = year.semesters[0].classes;
+      for (let j = 0; j < classes.length; j++) {
+        if (classes[j].id === course.id) {
+          return schedule[i].number;
+        }
+      }
+    }
+    return -1;
+  };
+
+  const extractYearsWithoutCourseYear = (course) => {
+    const years = schedule
+      .filter((year) => year.number != getYearNumberFromCourse(course))
+      .map((year) => year.number);
+    return years;
+  };
+
   return (
     <div className="schedule-tool">
       <div className="content">
@@ -129,7 +149,12 @@ export default function ScheduleTool() {
         <Modal
           isOpen={isOpen}
           handleCloseModal={handleCloseModal}
-          content={<SwapModal courseName={courseToChange.name} />}
+          content={
+            <SwapModal
+              courseName={courseToChange.name}
+              years={extractYearsWithoutCourseYear(courseToChange)}
+            />
+          }
         />
       </div>
     </div>

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -29,6 +29,7 @@ export default function ScheduleTool() {
   };
 
   const handleCloseModal = () => {
+    setOptions(null);
     setIsOpen(false);
   };
 
@@ -213,6 +214,7 @@ export default function ScheduleTool() {
               courseName={courseToChange.name}
               years={extractYearsWithoutCourseYear(courseToChange)}
               handleSubmitSwapRequest={handleSubmitSwapRequest}
+              options={options}
             />
           }
         />

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -20,6 +20,7 @@ export default function ScheduleTool() {
   const { user } = useContext(UserContext);
   const [isOpen, setIsOpen] = useState(false);
   const [courseToChange, setCourseToChange] = useState({});
+  const [options, setOptions] = useState(null);
 
   const handleOpenModal = (e, course) => {
     e.stopPropagation();
@@ -151,12 +152,36 @@ export default function ScheduleTool() {
     }
   };
 
+  const submitFullYearRequest = async (desiredYear) => {
+    const body = {
+      schedule,
+      scheduleAdjList,
+      courseToChange,
+      desiredYear,
+    };
+    try {
+      const res = await axios.post(
+        "http://localhost:5000/api/schedule/full-year-options",
+        body
+      );
+      if (res.data.validMoves.length !== 0) {
+        setOptions(res.data.validMoves);
+      } else {
+        alert("Can not move. Try a different course or year.");
+      }
+    } catch (error) {
+      alert("Something went wrong.");
+    }
+  };
+
   const handleSubmitSwapRequest = (desiredYear) => {
     // check if the year is full
     const yearIdx = schedule.findIndex((year) => year.number === desiredYear);
     if (schedule[yearIdx].semesters[0].classes.length !== 6) {
       // not full
       submitNonFullYearRequest(desiredYear);
+    } else {
+      submitFullYearRequest(desiredYear);
     }
   };
 

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -18,10 +18,12 @@ export default function ScheduleTool() {
   const [year, setYear] = useState(null);
   const { user } = useContext(UserContext);
   const [isOpen, setIsOpen] = useState(false);
+  const [courseToChange, setCourseToChange] = useState({});
 
-  const handleOpenModal = (e) => {
+  const handleOpenModal = (e, course) => {
     e.stopPropagation();
     setIsOpen(true);
+    setCourseToChange(course);
   };
 
   const handleCloseModal = () => {
@@ -127,7 +129,7 @@ export default function ScheduleTool() {
         <Modal
           isOpen={isOpen}
           handleCloseModal={handleCloseModal}
-          content={<SwapModal />}
+          content={<SwapModal courseName={courseToChange.name} />}
         />
       </div>
     </div>


### PR DESCRIPTION
Building out the frontend UI to support the course swap operations implemented on the application's server

1. SwapModal:
The main aspects of the swap operations all go through the swap modal.

- User starts by clicking on a class to bring up the swap modal
- Then, the user can choose what year they would like to swap the class to (except the one its currently in)
- If the year is not full (frontend check), the nonfull endpoint is hit to swap the course
- If the year is full (frontend check), the full-swap-option endpoint is hit to return the valid swaps for that year
- The swap modal is then populated with the valid swap options, and the user can choose the course to swap with

**All notifications of invalid moves occur through alerts

Overview of Swap Modal:
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/b3612e80-0e7c-47b7-b749-f923577e806d">

Options choice from Swap Modal:
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/8294081d-7783-4210-b02f-720da6b8fdeb">

Invalid move alert:
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/fecc9775-a70b-4d19-8ce9-55724d89b7a9">
