### PR TITLE
Front End - Admin Popover

### DIFF
--- a/advisor-backend/routes/events.js
+++ b/advisor-backend/routes/events.js
@@ -141,7 +141,8 @@ router.get("/recommended/:studentId", async (req, res) => {
       city,
         state,
         description,
-        admin,
+        admin_firstname,
+        admin_lastname,
         date,
         title,
         time,
@@ -266,10 +267,12 @@ router.get("/recommended/:studentId", async (req, res) => {
   
     SELECT
     id,
+    e."AdminId" as AdminId,
     city,
       state,
       description,
-      admin,
+      admin_firstname,
+      admin_lastname,
       date,
       title,
       latitude,

--- a/advisor-ui/src/components/OpportunityModal/OpportunityModal.jsx
+++ b/advisor-ui/src/components/OpportunityModal/OpportunityModal.jsx
@@ -16,6 +16,9 @@ export default function OpportunityModal({ eventItem }) {
   const [eventOccurred, setEventOccurred] = useState(false);
   const { user } = useContext(UserContext);
   const [imgData, setImgData] = useState(null);
+  const [adminInfo, setAdminInfo] = useState(null);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
 
   const createStudentSignup = async () => {
     const body = {
@@ -78,6 +81,17 @@ export default function OpportunityModal({ eventItem }) {
     }
   };
 
+  const handlePopoverOpen = (event) => {
+    if (adminInfo === null) {
+      fetchAdminInfo();
+    }
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+
   const createDateFromTimeStamp = (timestamp) => {
     const date = new Date(timestamp);
     const year = date.getFullYear();
@@ -106,6 +120,19 @@ export default function OpportunityModal({ eventItem }) {
     }
   };
 
+  const fetchAdminInfo = async () => {
+    try {
+      const res = await axios.get(
+        `http://localhost:5000/api/admin/${
+          eventItem.AdminId ?? eventItem.adminid
+        }`
+      );
+      setAdminInfo(res.data.admin);
+    } catch (error) {
+      alert("Something went wrong!");
+    }
+  };
+
   useEffect(() => {
     compareDates();
     fetchMap();
@@ -124,7 +151,11 @@ export default function OpportunityModal({ eventItem }) {
           <CalendarMonthIcon />
           <p>{createDateFromTimeStamp(eventItem.date)}</p>
         </div>
-        <div className="admin">
+        <div
+          className="admin"
+          onMouseEnter={handlePopoverOpen}
+          onMouseLeave={handlePopoverClose}
+        >
           <SupervisorAccountIcon />
           <p>{`${eventItem.admin_firstname} ${eventItem.admin_lastname}`}</p>
         </div>

--- a/advisor-ui/src/components/OpportunityModal/OpportunityModal.jsx
+++ b/advisor-ui/src/components/OpportunityModal/OpportunityModal.jsx
@@ -126,7 +126,7 @@ export default function OpportunityModal({ eventItem }) {
         </div>
         <div className="admin">
           <SupervisorAccountIcon />
-          <p>{eventItem.admin}</p>
+          <p>{`${eventItem.admin_firstname} ${eventItem.admin_lastname}`}</p>
         </div>
         <div className="description">
           <div className="icon-title">

--- a/advisor-ui/src/components/OpportunityModal/OpportunityModal.jsx
+++ b/advisor-ui/src/components/OpportunityModal/OpportunityModal.jsx
@@ -8,6 +8,9 @@ import InputForm from "../InputForm/InputForm";
 import { Button } from "@mui/material";
 import { UserContext } from "../../UserContext.js";
 import axios from "axios";
+import Popover from "../Popover/Popover";
+import Persona from "../Persona/Persona";
+import { CircularProgress } from "@mui/material";
 
 export default function OpportunityModal({ eventItem }) {
   // YYYY-MM-DD = 10 chars
@@ -159,6 +162,18 @@ export default function OpportunityModal({ eventItem }) {
           <SupervisorAccountIcon />
           <p>{`${eventItem.admin_firstname} ${eventItem.admin_lastname}`}</p>
         </div>
+        <Popover
+          open={open}
+          handlePopoverClose={handlePopoverClose}
+          content={
+            adminInfo !== null ? (
+              <Persona userInfo={adminInfo} />
+            ) : (
+              <CircularProgress />
+            )
+          }
+          anchorEl={anchorEl}
+        />
         <div className="description">
           <div className="icon-title">
             <InfoIcon />

--- a/advisor-ui/src/components/Persona/Persona.css
+++ b/advisor-ui/src/components/Persona/Persona.css
@@ -1,0 +1,10 @@
+.persona {
+  display: flex;
+  gap: 5px;
+}
+
+.persona .text {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+}

--- a/advisor-ui/src/components/Persona/Persona.jsx
+++ b/advisor-ui/src/components/Persona/Persona.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { blue } from "@mui/material/colors";
+import Avatar from "@mui/material/Avatar";
+import "./Persona.css";
+
+export default function Persona({ userInfo }) {
+  const createNameAbbreviation = (firstname, lastname) => {
+    const firstAbbreviation = firstname.charAt(0);
+    const lastAbbreviation = lastname.charAt(0);
+    return `${firstAbbreviation}${lastAbbreviation}`;
+  };
+
+  return (
+    <div className="persona">
+      <Avatar sx={{ bgcolor: blue[500] }}>
+        {createNameAbbreviation(userInfo.firstname, userInfo.lastname)}
+      </Avatar>
+      <div className="text">
+        <p>{`${userInfo.firstname} ${userInfo.lastname}`}</p>
+        <p>{userInfo.email}</p>
+      </div>
+    </div>
+  );
+}

--- a/advisor-ui/src/components/Popover/Popover.jsx
+++ b/advisor-ui/src/components/Popover/Popover.jsx
@@ -1,0 +1,40 @@
+import { Popover as PopoverUI } from "@mui/material";
+import Box from "@mui/material/Box";
+
+export default function Popover({
+  anchorEl,
+  open,
+  handlePopoverClose,
+  content,
+}) {
+  return (
+    <div>
+      <PopoverUI
+        id="mouse-over-popover"
+        sx={{
+          pointerEvents: "none",
+        }}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+        onClose={handlePopoverClose}
+        disableRestoreFocus
+      >
+        <Box
+          sx={{
+            p: "10px",
+          }}
+        >
+          {content}
+        </Box>
+      </PopoverUI>
+    </div>
+  );
+}


### PR DESCRIPTION
Created frontend for the admin fetch endpoint created on the backend

1. When the user hovers over the name in the opportunity modal, a popover with a "persona" component appears
- The "persona" component contains the admin's email, so students can reach out to them preemptively for questions.

2. Adjusted admin display in event modal as well as select statements in recommendation algo query to align with new data format for event model (admin_firstname and admin_lastname)

Overview:
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/df23d764-ad59-42f9-b6cc-2357520f0898">
