### PR TITLE
Frontend - Save Schedules

### DIFF
--- a/advisor-ui/src/App.jsx
+++ b/advisor-ui/src/App.jsx
@@ -12,6 +12,7 @@ import StudentLanding from "./pages/StudentLanding/StudentLanding";
 import VolunteerExplore from "./pages/VolunteerExplore/VolunteerExplore";
 import VolunteerHours from "./pages/VolunteerHours/VolunteerHours";
 import Progress from "./pages/Progress/Progress";
+import SavedSchedules from "./pages/SavedSchedules/SavedSchedules";
 
 function App() {
   const [user, setUser] = useState(() => {
@@ -45,6 +46,10 @@ function App() {
               element={<VolunteerHours />}
             />
             <Route path="/student/progress" element={<Progress />} />
+            <Route
+              path="/student/saved-schedules"
+              element={<SavedSchedules />}
+            />
           </Routes>
         </BrowserRouter>
       </UserContext.Provider>

--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.css
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.css
@@ -1,0 +1,46 @@
+.saved-schedules {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.saved-schedules > .content {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  margin-top: 30px;
+}
+
+.saved-schedules > .content > .back-btn {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.saved-schedules > .content > .header {
+  align-items: flex-start;
+  display: flex;
+  width: 100%;
+}
+
+.saved-schedules > .content > .schedule-details h3 {
+  display: none;
+}
+
+.saved-schedules
+  > .content
+  > .schedule-details
+  > .content
+  > .display-years
+  > .year-details {
+  cursor: default;
+}
+
+.saved-schedules > .pagination {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}

--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
@@ -5,6 +5,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { UserContext } from "../../UserContext";
 import axios from "axios";
 import ScheduleDetails from "../../components/ScheduleDetails/ScheduleDetails";
+import "./SavedSchedules.css";
 
 export default function SavedSchedules() {
   const [schedules, setSchedules] = useState([]);

--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
@@ -7,6 +7,7 @@ import axios from "axios";
 
 export default function SavedSchedules() {
   const [schedules, setSchedules] = useState([]);
+  const [pageCount, setPageCount] = useState(null);
   const { user } = useContext(UserContext);
 
   const fetchSchedulesByPage = async (page) => {
@@ -20,7 +21,20 @@ export default function SavedSchedules() {
     }
   };
 
+  const fetchPageCount = async () => {
+    try {
+      const res = await axios.get(
+        `http://localhost:5000/api/save-schedule/${user.id}/page-count`
+      );
+      const pageCount = res.data.pageCount;
+      setPageCount(pageCount);
+    } catch (error) {
+      alert("Something went wrong. Try again later.");
+    }
+  };
+
   useEffect(() => {
+    fetchPageCount();
     fetchSchedulesByPage(1);
   }, []);
 

--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
@@ -1,0 +1,3 @@
+export default function SavedSchedules() {
+  return <div className="saved-schedules">saved schedules</div>;
+}

--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
@@ -1,8 +1,29 @@
+import { useContext, useState, useEffect } from "react";
 import { Pagination } from "@mui/material";
 import { Link } from "react-router-dom";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { UserContext } from "../../UserContext";
+import axios from "axios";
 
 export default function SavedSchedules() {
+  const [schedules, setSchedules] = useState([]);
+  const { user } = useContext(UserContext);
+
+  const fetchSchedulesByPage = async (page) => {
+    try {
+      const res = await axios.get(
+        `http://localhost:5000/api/save-schedule/${user.id}/${page}`
+      );
+      setSchedules(res.data.schedules);
+    } catch (error) {
+      alert("Something went wrong here.");
+    }
+  };
+
+  useEffect(() => {
+    fetchSchedulesByPage(1);
+  }, []);
+
   return (
     <div className="saved-schedules">
       <div className="content">

--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
@@ -1,3 +1,23 @@
+import { Pagination } from "@mui/material";
+import { Link } from "react-router-dom";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+
 export default function SavedSchedules() {
-  return <div className="saved-schedules">saved schedules</div>;
+  return (
+    <div className="saved-schedules">
+      <div className="content">
+        <div className="back-btn">
+          <Link to="/student/schedule">
+            <ArrowBackIcon className="back" />
+          </Link>
+        </div>
+        <div className="header">
+          <h3>Saved Schedules:</h3>
+        </div>
+        <div className="pagination">
+          <Pagination count={2} />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.jsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { UserContext } from "../../UserContext";
 import axios from "axios";
+import ScheduleDetails from "../../components/ScheduleDetails/ScheduleDetails";
 
 export default function SavedSchedules() {
   const [schedules, setSchedules] = useState([]);
@@ -33,6 +34,10 @@ export default function SavedSchedules() {
     }
   };
 
+  const scheduleDisplay = schedules.map((schedule, idx) => (
+    <ScheduleDetails className="overview" key={idx} years={schedule} />
+  ));
+
   useEffect(() => {
     fetchPageCount();
     fetchSchedulesByPage(1);
@@ -49,9 +54,15 @@ export default function SavedSchedules() {
         <div className="header">
           <h3>Saved Schedules:</h3>
         </div>
-        <div className="pagination">
-          <Pagination count={2} />
-        </div>
+        {scheduleDisplay}
+        {pageCount !== null && (
+          <div className="pagination">
+            <Pagination
+              count={pageCount}
+              onChange={(event, page) => fetchSchedulesByPage(page)}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -253,6 +253,7 @@ export default function ScheduleTool() {
             <ArrowBackIcon className="back" />
           </Link>
         </div>
+        <Link to="/student/saved-schedules">View Saved Schedules</Link>
         <Constraints constraints={constraints} addConstraint={addConstraint} />
         <Button variant="outlined" onClick={generateNewSchedule}>
           Generate New Schedule:

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.jsx
@@ -220,6 +220,31 @@ export default function ScheduleTool() {
     }
   };
 
+  const createSaveScheduleRecord = async () => {
+    const body = {
+      StudentId: user.id,
+      schedule,
+    };
+    try {
+      const res = await axios.post(
+        "http://localhost:5000/api/save-schedule/create",
+        body
+      );
+      alert("Save successful!");
+    } catch (error) {
+      alert("Something went wrong.");
+    }
+  };
+
+  const handleSaveSchedule = () => {
+    if (schedule.length !== 0) {
+      createSaveScheduleRecord();
+    } else {
+      alert("Generate a schedule first.");
+      return;
+    }
+  };
+
   return (
     <div className="schedule-tool">
       <div className="content">
@@ -231,6 +256,9 @@ export default function ScheduleTool() {
         <Constraints constraints={constraints} addConstraint={addConstraint} />
         <Button variant="outlined" onClick={generateNewSchedule}>
           Generate New Schedule:
+        </Button>
+        <Button variant="outlined" onClick={handleSaveSchedule}>
+          save
         </Button>
         <ScheduleDetails
           years={schedule}


### PR DESCRIPTION
Frontend implementation to support students saving schedules

1. ScheduleTool Page:
- Added a link to the saved schedules page
- Implemented a function to create a new schedule record in the DB
- Function call made when schedule is present and "save" button is pressed

2. (NEW) SavedSchedules Page:
- Displays schedule records
- Page limit set to one to display one schedule at a time
- Pagination MUI component to allow users to switch through schedules

ScheduleTool Screen:
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/02267bf7-10c1-4a7b-9b3c-68ff2fb361ad">
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/28b7f076-7362-4b41-9889-24c5c5afa307">

SaveSchedules Screen:
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/a511cea0-ac8f-4406-812a-963eb863336e">

