### PR TITLE
Academic Progress Page Responsiveness

### DIFF
--- a/advisor-ui/src/components/ClassProgressCard/ClassProgressCard.css
+++ b/advisor-ui/src/components/ClassProgressCard/ClassProgressCard.css
@@ -6,7 +6,7 @@
   flex-direction: column;
   justify-content: center;
   padding: 10px;
-  width: 300px;
+  width: 250px;
 }
 
 .class-progress-card .content {

--- a/advisor-ui/src/index.css
+++ b/advisor-ui/src/index.css
@@ -12,6 +12,11 @@ h1 {
   font-weight: 800;
 }
 
+h2 {
+  font-size: 36px;
+  font-weight: 600;
+}
+
 h3 {
   font-size: 30px;
   font-weight: 500;

--- a/advisor-ui/src/pages/Progress/Progress.css
+++ b/advisor-ui/src/pages/Progress/Progress.css
@@ -10,10 +10,11 @@
   gap: 30px;
   margin: 0 auto;
   margin-top: 30px;
-  max-width: 1200px;
+  max-width: 900px;
 }
 
 .progress > .content > .header {
+  align-items: center;
   display: flex;
   justify-content: center;
 }
@@ -23,7 +24,26 @@
 }
 
 .progress > .content > .grid {
-  display: grid;
-  grid-template-columns: 300px 300px 300px;
-  grid-gap: 30px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
+}
+
+@media (max-width: 1150px) {
+  .progress > .content {
+    max-width: 700px;
+  }
+}
+
+@media (max-width: 800px) {
+  .progress > .content {
+    max-width: 500px;
+  }
+}
+
+@media (max-width: 600px) {
+  .progress > .content {
+    max-width: 300px;
+  }
 }

--- a/advisor-ui/src/pages/Progress/Progress.jsx
+++ b/advisor-ui/src/pages/Progress/Progress.jsx
@@ -64,14 +64,14 @@ export default function Progress() {
             />
             <div className="text">
               {takenCount !== -1 && requiredCount !== -1 && (
-                <h1>{`You are ${Math.round(
+                <h2>{`You are ${Math.round(
                   (takenCount / requiredCount) * 100
-                )}% complete!`}</h1>
+                )}% complete!`}</h2>
               )}
               {takenCount !== -1 && requiredCount !== -1 && (
-                <h3>{`You have ${
+                <h4>{`You have ${
                   requiredCount - takenCount
-                } classes left until graduation!`}</h3>
+                } classes left until graduation!`}</h4>
               )}
             </div>
           </div>


### PR DESCRIPTION
This PR includes code adjustments to make the academic progress page responsive to different screen sizes. Responsiveness done primarily through the use of media queries to adjust the widths on different screens.

Overview (Standard Desktop):
<img width="1724" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/d3c9ed0d-9302-48ff-871c-ebb89ecd0631">

iPad Mini:
<img width="1378" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/c366d8fe-2caa-486e-8423-fdd97ce2959b">

iPhone:
<img width="1378" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/74396c1d-319a-4952-9c3a-99bca41497c2">
