### PR TITLE
Volunteer Hours Responsiveness

### DIFF
--- a/advisor-ui/src/pages/VolunteerHours/VolunteerHours.css
+++ b/advisor-ui/src/pages/VolunteerHours/VolunteerHours.css
@@ -9,11 +9,29 @@
   gap: 30px;
   margin: 0 auto;
   margin-top: 30px;
-  max-width: 1200px;
+  max-width: 900px;
 }
 
 .table {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+@media (max-width: 1150px) {
+  .volunteer-hours > .content {
+    max-width: 700px;
+  }
+}
+
+@media (max-width: 800px) {
+  .volunteer-hours > .content {
+    max-width: 500px;
+  }
+}
+
+@media (max-width: 600px) {
+  .volunteer-hours > .content {
+    max-width: 300px;
+  }
 }


### PR DESCRIPTION
In this PR, CSS was updated to ensure the volunteer hours page is responsive to different screen sizes.

As the screen width becomes smaller and smaller than the iPad width, the width becomes too small to shrink the table anymore, thus, the table becomes scrollable to view all contents.

Overview (Standard Desktop):
<img width="1716" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/3ebdb37e-2e61-407a-bc03-4f7c94bc7a4a">

iPad:
<img width="1380" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/fc1f2a80-a430-44a2-abfd-3af3bbda5919">

iPhone:
<img width="1380" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/175d8427-984a-4733-9210-cf3b99032345">
