### PR TITLE
Volunteer Explore Page - Responsiveness

### DIFF
--- a/advisor-ui/src/components/Explore/Explore.css
+++ b/advisor-ui/src/components/Explore/Explore.css
@@ -19,6 +19,29 @@
   grid-auto-rows: 255px;
 }
 
-.progress {
-  margin-top: 30px;
+@media (max-width: 1150px) {
+  .explore > .content > .grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 215px 215px 215px;
+    grid-auto-rows: 255px;
+  }
+}
+
+@media (max-width: 800px) {
+  .explore > .content > .grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 215px 215px;
+    grid-auto-rows: 255px;
+  }
+}
+
+@media (max-width: 600px) {
+  .explore > .content > .grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 215px;
+    grid-auto-rows: 255px;
+  }
 }

--- a/advisor-ui/src/components/OpportunityModal/OpportunityModal.css
+++ b/advisor-ui/src/components/OpportunityModal/OpportunityModal.css
@@ -44,3 +44,15 @@
   gap: 10px;
   width: 100%;
 }
+
+@media (max-width: 600px) {
+  .opp-modal .content #map {
+    width: 300px;
+  }
+}
+
+@media (max-width: 400px) {
+  .opp-modal .content #map {
+    width: 250px;
+  }
+}

--- a/advisor-ui/src/components/PreferenceModal/PreferenceModal.css
+++ b/advisor-ui/src/components/PreferenceModal/PreferenceModal.css
@@ -18,3 +18,15 @@
   display: flex;
   gap: 10px;
 }
+
+@media (max-width: 700px) {
+  .preference-modal .content {
+    width: 300px;
+  }
+}
+
+@media (max-width: 400px) {
+  .preference-modal .content {
+    width: 275px;
+  }
+}

--- a/advisor-ui/src/components/Recommend/Recommend.css
+++ b/advisor-ui/src/components/Recommend/Recommend.css
@@ -27,3 +27,30 @@
   grid-auto-rows: 255px;
   grid-template-columns: 215px 215px 215px 215px;
 }
+
+@media (max-width: 1150px) {
+  .recommend > .content > .grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 215px 215px 215px;
+    grid-auto-rows: 255px;
+  }
+}
+
+@media (max-width: 800px) {
+  .recommend > .content > .grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 215px 215px;
+    grid-auto-rows: 255px;
+  }
+}
+
+@media (max-width: 600px) {
+  .recommend > .content > .grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 215px;
+    grid-auto-rows: 255px;
+  }
+}

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.css
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.css
@@ -1,15 +1,15 @@
 .volunteer-explore {
+  align-items: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
 }
 
 .volunteer-explore > .content {
-  margin-top: 30px;
-  display: flex;
-  flex-direction: column;
   align-items: flex-start;
+  display: flex;
   gap: 30px;
+  flex-direction: column;
+  margin-top: 30px;
   width: 900px;
 }
 

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.css
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.css
@@ -10,6 +10,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 30px;
+  width: 900px;
 }
 
 .nav-links {
@@ -24,4 +25,22 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+}
+
+@media (max-width: 1150px) {
+  .volunteer-explore > .content {
+    width: 700px;
+  }
+}
+
+@media (max-width: 800px) {
+  .volunteer-explore > .content {
+    width: 500px;
+  }
+}
+
+@media (max-width: 600px) {
+  .volunteer-explore > .content {
+    width: 300px;
+  }
 }

--- a/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
+++ b/advisor-ui/src/pages/VolunteerExplore/VolunteerExplore.jsx
@@ -11,7 +11,6 @@ import { UserContext } from "../../UserContext.js";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Pagination from "@mui/material/Pagination";
 // utils imports
-import apiBase from "../../utils/apiBase";
 import {
   fetchRecommendedEvents,
   fetchEventsByPage,
@@ -124,7 +123,7 @@ export default function VolunteerExplore() {
             <ArrowBackIcon className="back" />
           </Link>
           <Link to="/student/volunteer/hours" className="nav-text">
-            View Your Volunteer History
+            View Volunteer History
           </Link>
         </div>
         <Recommend


### PR DESCRIPTION
This PR is focused solely on adjusting CSS property styling and using media queries to make the volunteer explore tool responsive to different user screen sizes.

Overview (Standard Desktop):
<img width="1726" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/da4361d0-c971-431c-a011-d5ca9d22125a">

iPad:
<img width="1249" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/9dbdb2a5-2a90-49d4-97ef-cccc4d2a25cf">

iPhone:
<img width="1249" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/12478132-e0f0-4e54-87be-0431768e0328">


Opportunity/Preference Modals (iPad):
<img width="1249" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/7187c210-144d-4314-b6c1-d8c856e1eda4">
<img width="1249" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/45477880-f03e-47b4-8a38-514160099674">


Opportunity/Preference Modals (iPhones):
<img width="1249" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/474b2429-121b-4d6c-9368-abac6f0aba65">
<img width="1249" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/061584c2-b0d0-4afe-aabc-f5a81f17b6c2">

