### PR TITLE
Schedule Tool Responsiveness

### DIFF
--- a/advisor-ui/src/components/AddConstraint/AddConstraint.css
+++ b/advisor-ui/src/components/AddConstraint/AddConstraint.css
@@ -1,4 +1,4 @@
 .add-constraint {
   height: 30px;
-  width: 180px;
+  width: 176px;
 }

--- a/advisor-ui/src/components/ClassDetails/ClassDetails.css
+++ b/advisor-ui/src/components/ClassDetails/ClassDetails.css
@@ -26,17 +26,15 @@
   width: fit-content;
 }
 
-.schedule-details
-  > .content
-  > .display-year
-  > .year-details
-  > .content
-  > .semester-details
-  > .content
-  > .class-details
-  > .details {
-  align-items: first baseline;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+@media (max-width: 1150px) {
+  .schedule-details
+    > .content
+    > .display-year
+    > .year-details
+    > .content
+    > .semester-details
+    > .content
+    > .class-details {
+    width: 100%;
+  }
 }

--- a/advisor-ui/src/components/ConstraintItem/ConstraintItem.css
+++ b/advisor-ui/src/components/ConstraintItem/ConstraintItem.css
@@ -1,4 +1,4 @@
 .constraint-item {
   height: 30px;
-  width: 180px;
+  width: 176px;
 }

--- a/advisor-ui/src/components/Constraints/Constraints.css
+++ b/advisor-ui/src/components/Constraints/Constraints.css
@@ -1,17 +1,37 @@
 .constraints .content {
+  align-items: center;
   border: 1px solid #1976d2;
   border-radius: 5px;
   display: flex;
-  height: 100px;
+  height: fit-content;
   justify-content: center;
   margin-top: 10px;
   padding: 5px;
-  width: 735px;
+  width: 900px;
 }
 
 .constraints .content .grid {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 5px;
-  grid-auto-rows: 30px;
-  grid-template-columns: 180px 180px 180px 180px;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+@media (max-width: 1150px) {
+  .constraints > .content {
+    width: 538px;
+  }
+}
+
+@media (max-width: 800px) {
+  .constraints > .content {
+    width: 358px;
+  }
+}
+
+@media (max-width: 600px) {
+  .constraints > .content {
+    width: 176px;
+  }
 }

--- a/advisor-ui/src/components/ScheduleDetails/ScheduleDetails.css
+++ b/advisor-ui/src/components/ScheduleDetails/ScheduleDetails.css
@@ -1,13 +1,20 @@
 .schedule-details {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 900px;
+}
+
+.schedule-details > .content {
+  width: 100%;
 }
 
 .schedule-details > .content > .display-years {
   display: flex;
-  gap: 30px;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  width: 100%;
 }
 
 .schedule-details > .content > .display-year {
@@ -15,4 +22,23 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 100%;
+}
+
+@media (max-width: 1150px) {
+  .schedule-details {
+    width: 548px;
+  }
+}
+
+@media (max-width: 800px) {
+  .schedule-details {
+    width: 372px;
+  }
+}
+
+@media (max-width: 600px) {
+  .schedule-details {
+    width: 180px;
+  }
 }

--- a/advisor-ui/src/components/SemesterDetails/SemesterDetails.css
+++ b/advisor-ui/src/components/SemesterDetails/SemesterDetails.css
@@ -26,3 +26,17 @@
   flex-direction: row;
   gap: 10px;
 }
+
+@media (max-width: 1150px) {
+  .schedule-details
+    > .content
+    > .display-year
+    > .year-details
+    > .content
+    > .semester-details
+    > .content {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+}

--- a/advisor-ui/src/components/YearDetails/YearDetails.css
+++ b/advisor-ui/src/components/YearDetails/YearDetails.css
@@ -13,7 +13,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 5px;
+  padding: 10px;
   transition: 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   width: fit-content;
 }
@@ -28,4 +28,12 @@
 
 .schedule-details > .content > .display-year > .year-details > .content:hover {
   background-color: transparent;
+}
+
+@media (max-width: 1150px) {
+  .schedule-details > .content > .display-year > .year-details > .content {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
 }

--- a/advisor-ui/src/components/YearDetails/YearDetails.css
+++ b/advisor-ui/src/components/YearDetails/YearDetails.css
@@ -1,8 +1,8 @@
 .year-details {
-  width: fit-content;
+  align-items: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  width: fit-content;
 }
 
 .year-details > .content {

--- a/advisor-ui/src/pages/ScheduleTool/ScheduleTool.css
+++ b/advisor-ui/src/pages/ScheduleTool/ScheduleTool.css
@@ -10,6 +10,7 @@
   flex-direction: column;
   gap: 30px;
   margin-top: 30px;
+  width: 900px;
 }
 
 .schedule-tool > .content > .nav-links {
@@ -22,4 +23,22 @@
 .schedule-tool .content .btn-container {
   display: flex;
   gap: 1em;
+}
+
+@media (max-width: 1150px) {
+  .schedule-tool > .content {
+    width: 700px;
+  }
+}
+
+@media (max-width: 800px) {
+  .schedule-tool > .content {
+    width: 500px;
+  }
+}
+
+@media (max-width: 600px) {
+  .schedule-tool > .content {
+    width: 300px;
+  }
 }


### PR DESCRIPTION
This PR focuses on using media queries to adjust the width of different components to accommodate various screen sizes.

**Overview** 
Standard Desktop:
<img width="1721" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/67b14f75-67c9-417e-8ffe-40a9d6507e07">

iPad:
<img width="1241" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/b9333946-5c37-48f3-aa19-f25694f35943">

iPhone:
<img width="1241" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/ec6899df-4e1f-4c61-8934-eafc7b009c92">


**Class Details View**
Standard Dekstop:
<img width="1724" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/796fdce0-a55b-4c54-b3f8-8c71e5ddcf05">

iPad:
<img width="1241" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/f7f4c8c9-c0e5-47dd-b3db-dbc6ce9b9d81">

iPhone:
<img width="1241" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/09374ad8-a1fd-498b-ba96-9494200080a4">

