### PR TITLE
Save Schedule Responsiveness

### DIFF
--- a/advisor-ui/src/pages/SavedSchedules/SavedSchedules.css
+++ b/advisor-ui/src/pages/SavedSchedules/SavedSchedules.css
@@ -10,6 +10,7 @@
   flex-direction: column;
   gap: 30px;
   margin-top: 30px;
+  width: 900px;
 }
 
 .saved-schedules > .content > .back-btn {
@@ -38,9 +39,32 @@
   cursor: default;
 }
 
+.saved-schedules > .content > .schedule-details > .content > .display-years {
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
 .saved-schedules > .pagination {
   align-items: center;
   display: flex;
   flex-direction: column;
   width: 100%;
+}
+
+@media (max-width: 1150px) {
+  .saved-schedules > .content {
+    width: 700px;
+  }
+}
+
+@media (max-width: 800px) {
+  .saved-schedules > .content {
+    width: 500px;
+  }
+}
+
+@media (max-width: 600px) {
+  .saved-schedules > .content {
+    width: 300px;
+  }
 }


### PR DESCRIPTION
In this PR, the width of the save schedule page is changed depending upon the screen width. In addition, the content display container that displays all of the year is changed to flex-wrap to ensure content will adjust as the screen width changes.

Overview:
<img width="1724" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/6d72dad4-68f7-43f5-97a7-f88ebf267164">

iPad:
<img width="1245" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/a8a65894-1d73-4edd-ac64-282b69bfa29f">

iPhone:
<img width="1245" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/f4d7d4ba-dca0-4d18-a92a-89360f618e79">
