### PR TITLE
Student Landing Page - Responsiveness

### DIFF
--- a/advisor-ui/src/components/LandingMenuNav/LandingMenuNav.css
+++ b/advisor-ui/src/components/LandingMenuNav/LandingMenuNav.css
@@ -37,3 +37,12 @@
   text-decoration: none;
   width: 100%;
 }
+
+@media (max-width: 1150px) {
+  .landing-menu-nav > .content > img {
+    width: 50%;
+  }
+  .landing-menu-nav > .content {
+    flex-direction: row;
+  }
+}

--- a/advisor-ui/src/pages/StudentLanding/StudentLanding.css
+++ b/advisor-ui/src/pages/StudentLanding/StudentLanding.css
@@ -17,6 +17,7 @@
   flex-direction: column;
   gap: 80px;
   justify-content: space-evenly;
+  width: 900px;
 }
 
 .student-landing > .content > .main {
@@ -31,4 +32,27 @@
   display: flex;
   flex-direction: row;
   gap: 30px;
+}
+
+@media (max-width: 1150px) {
+  .student-landing > .content {
+    width: 700px;
+  }
+  .student-landing .buttons {
+    align-items: center;
+    flex-direction: column;
+    gap: 30px;
+  }
+}
+
+@media (max-width: 800px) {
+  .student-landing > .content {
+    width: 500px;
+  }
+}
+
+@media (max-width: 600px) {
+  .student-landing > .content {
+    width: 300px;
+  }
 }


### PR DESCRIPTION
This PR is focused on making the student landing page responsive. As the screen width gets smaller, the width of the student landing page decreases as well. 

When the screen width is smaller than 1150px, the container holding all of the LandingNavMenu components switches from a row display to a column display. In addition, the LandingMenuNav component img's are set to a smaller width and the display of the component is switched from column to row to save space.

Overview (Standard Desktop):
<img width="1692" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/72fb81b9-d7d6-4730-8770-e476d5382170">

iPad:
<img width="1210" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/853e4395-bd4f-47b4-a4a7-484d9361fa15">

iPhone:
<img width="1210" alt="image" src="https://github.com/DayRB25/MetaUFinal/assets/80652550/b2666bee-7dec-4ca7-904d-cb6e6204b078">
